### PR TITLE
Fix model$vtypes typo: should be model$vtype (breaks with Gurobi 12)

### DIFF
--- a/bestsubset/R/bs.R
+++ b/bestsubset/R/bs.R
@@ -184,7 +184,7 @@ bs.one.k = function(x, y, k, xtx, form=ifelse(nrow(x)<ncol(x),2,1),
     model$lb = c(rep(-bigm,p), rep(0,p))
     model$obj = c(-2*t(x)%*%y, rep(0,p))     # The vector c in the objective
     model$Q = bdiag(xtx, Matrix(0,p,p))
-    model$vtypes = c(rep("C",p), rep("B",p)) # Variable type: cont or binary
+    model$vtype = c(rep("C",p), rep("B",p)) # Variable type: cont or binary
     model$start = c(best.beta, zvec)         # Warm start from proj gradient
   }
   else {
@@ -199,7 +199,7 @@ bs.one.k = function(x, y, k, xtx, form=ifelse(nrow(x)<ncol(x),2,1),
     model$lb = c(rep(-bigm,p), rep(0,p), rep(-zeta.bd,n))
     model$obj = c(-2*t(x)%*%y, rep(0,p+n))       # The vector c in the objective
     model$Q = bdiag(Matrix(0,2*p,2*p), Diagonal(n,1))
-    model$vtypes = c(rep("C",p), rep("B",p), rep("C",n)) # Variable type
+    model$vtype = c(rep("C",p), rep("B",p), rep("C",n)) # Variable type
     model$start = c(best.beta, zvec, x%*%best.beta)      # Warm start
   }
 


### PR DESCRIPTION
**Bug**: `bs.R` lines 187 and 202 use `model$vtypes` (plural), but the documented field name in Gurobi's R API is `model$vtype` (singular). (See: https://docs.gurobi.com/projects/optimizer/en/current/reference/r/common.html)
While `vtypes` appears to have been accepted as an undocumented alias in Gurobi 11 and earlier, Gurobi 12 no longer recognizes it, causing all variables to be treated as continuous and the MIP solver to never be invoked. This change is not mentioned in Gurobi 12's release notes.

**Fix**: Change `model$vtypes` to `model$vtype` on lines 187 and 202 of `bs.R`.